### PR TITLE
Fix case sensitivity on 100k R16

### DIFF
--- a/Mechaduino01.brd
+++ b/Mechaduino01.brd
@@ -10929,7 +10929,7 @@ design rules under a new name.</description>
 </element>
 <element name="U$3" library="stepper_servo_prototype_1" package="LOGO3" value="TROPICAL_LABS_LOGO_1LOGO3" x="6.096" y="12.192" rot="R90"/>
 <element name="J1" library="MF_Connectors" package="MICROUSB-RIGHT" value="" x="38.735" y="20.166" locked="yes" smashed="yes" rot="R90"/>
-<element name="R16" library="adafruit" package="R0402-VISHAY" value="100k" x="3.175" y="27.813" rot="MR180"/>
+<element name="R16" library="adafruit" package="R0402-VISHAY" value="100K" x="3.175" y="27.813" rot="MR180"/>
 <element name="F1" library="SparkFun-PowerIC" package="PTC-1206" value="500mA" x="20.574" y="15.621" smashed="yes" rot="MR0">
 <attribute name="PROD_ID" value="RES-11150" x="30.099" y="23.876" size="1.778" layer="28" rot="MR0" display="off"/>
 </element>

--- a/Mechaduino01.sch
+++ b/Mechaduino01.sch
@@ -36761,7 +36761,7 @@ Source: AVX .. aphvc.pdf</description>
 <part name="U$3" library="stepper_servo_prototype_1" deviceset="TROPICAL_LABS_LOGO_1" device="LOGO3" value="TROPICAL_LABS_LOGO_1LOGO3"/>
 <part name="J1" library="MF_Connectors" deviceset="USB" device="_MICRO_RIGHT"/>
 <part name="FRAME1" library="SparkFun-Aesthetics" deviceset="FRAME-LEDGER" device=""/>
-<part name="R16" library="adafruit" deviceset="R-US_" device="R0402-VISHAY" value="100k"/>
+<part name="R16" library="adafruit" deviceset="R-US_" device="R0402-VISHAY" value="100K"/>
 <part name="GND20" library="supply1" deviceset="GND" device=""/>
 <part name="F1" library="SparkFun-PowerIC" deviceset="PTC" device="SMD" value="500mA"/>
 <part name="Q1" library="SparkFun-DiscreteSemi" deviceset="MOSFET-PCHANNEL" device="DMG2307L" value="2.5A/30V"/>


### PR DESCRIPTION
Case sensitivity in BOM export causes 2 seperate entries in the BOM
under the 100k resistors.  Ks are mostly capitalized throughout the
schematic, so corrected this one.
